### PR TITLE
Support GNOME 46

### DIFF
--- a/tibr-ext@andypiper.org/metadata.json
+++ b/tibr-ext@andypiper.org/metadata.json
@@ -3,6 +3,7 @@
   "description": "Stream The Indie Beat Radio - independent music from artists in the Fediverse.\nUses API and streams from theindiebeat.fm.\nRequires Gstreamer and plugins.",
   "uuid": "tibr-ext@andypiper.org",
   "shell-version": [
+    "46",
     "47"
   ],
   "url": "https://github.com/andypiper/theindiebeat-gnome-ext",


### PR DESCRIPTION
GNOME 46 is still shipped with Ubuntu's latest LTS

After a very cursory check it seems to work without any other changes